### PR TITLE
fixed @designsystemau/gold-design-system-site#15

### DIFF
--- a/src/js/a11y/020-tabbing.js
+++ b/src/js/a11y/020-tabbing.js
@@ -25,7 +25,9 @@ AddEvent( document.querySelector( '.js-tabbing-switch' ), 'click', function( eve
  * Event listener for when the user scrolls or uses the tab key to stop Tab() function
  */
 AddEvent( document.querySelector( '.tabbing-frame' ), 'keydown', function( event, $this ) {
-	StopTab( interval, document.querySelector( '.js-tabbing-switch' ) )
+	if( HasClass(document.querySelector( '.js-tabbing-switch' ), 'is-on' ) ) {
+		StopTab( interval, document.querySelector( '.js-tabbing-switch' ) );
+	}
 });
 
 
@@ -39,11 +41,12 @@ function Tab() {
 	return setInterval( function() {
 		if( loop >= items.length ) {
 			StopTab( interval, document.querySelector( '.js-tabbing-switch' ) );
-			document.querySelector( '.js-tabbing-switch' ).focus()
-		} else {
-			items[ loop ].focus();
-			loop ++;
 		}
+		else {
+			items[ loop ].focus();
+		}
+
+		loop ++;
 	}, 500 );
 }
 
@@ -55,4 +58,5 @@ function StopTab( interval, $this ) {
 	RemoveClass( $this, 'is-on' );
 	$this.innerText = 'Show tabbing';
 	clearInterval( interval );
+	$this.focus();
 }

--- a/src/js/footer/010-helper.js
+++ b/src/js/footer/010-helper.js
@@ -115,32 +115,32 @@ function GetSelectedFormItems( id ){
 // IE8+ complaint polyfill for String.trim();
 if(typeof String.prototype.trim !== 'function') {
 	String.prototype.trim = function() {
-	  return this.replace(/^\s+|\s+$/g, '');
+		return this.replace(/^\s+|\s+$/g, '');
 	};
 }
 
 //IE8 compliant polyfill for next element sibling
 // Source: https://github.com/Alhadis/Snippets/blob/master/js/polyfills/IE8-child-elements.js
 if(!("nextElementSibling" in document.documentElement)){
-    Object.defineProperty(Element.prototype, "nextElementSibling", {
-        get: function(){
-            var e = this.nextSibling;
-            while(e && 1 !== e.nodeType)
-                e = e.nextSibling;
-            return e;
-        }
-    });
+	Object.defineProperty(Element.prototype, "nextElementSibling", {
+		get: function(){
+			var e = this.nextSibling;
+			while(e && 1 !== e.nodeType)
+				e = e.nextSibling;
+			return e;
+		}
+	});
 }
 
 //IE8 compliant polyfill for previous element sibling
 // Source: https://github.com/Alhadis/Snippets/blob/master/js/polyfills/IE8-child-elements.js
-if(!("previousElementSibling" in document.documentElement)){
+if(!("previousElementSibling" in document.documentElement)) {
 	Object.defineProperty(Element.prototype, "previousElementSibling", {
-	  get: function(){
+		get: function(){
 		var e = this.previousSibling;
 		while(e && 1 !== e.nodeType)
-		  e = e.previousSibling;
+			e = e.previousSibling;
 		return e;
-	  }
+		}
 	});
-  }
+}


### PR DESCRIPTION
Hey @Zubiii 

I had a look at your issue and the solve.
The way you solved it wasn't correct because the root cause of this was that an event handler was added to `keydown` inside the tabbing area which means than whenever someone clicked any key including the <kbd>tab</kbd> key the `StopTab` function would run which included a `focus` call.
In this fix I have added a conditional that checks for the `is-on` class and only trigger the `StopTab` function if we are indeed within a focus round call.

Hope this makes sense.
Once you merge this PR into your `main` branch I can approve your PR in the designsystemau/gold-design-system-site repo.